### PR TITLE
fix in regex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ module.exports = exports = fn =>
         const parsedBody = body.split(`--${boundary}`);
 
         parsedBody.map(field => {
-          const nameSearch = field.match(/name=\"(.*)\"/);
+          const nameSearch = field.match(/name=\"(.*?)\"/);
 
           if (nameSearch) {
             const fieldName = nameSearch[1];


### PR DESCRIPTION
If a chunk is a file, like this:
...
--------------------------38e114a48fbda8d2
Content-Disposition: form-data; name="file"; filename="1.json"
Content-Type: application/octet-stream

{ "something": 1 }
--------------------------38e114a48fbda8d2
....

nameSearch[1] will be: 'file"; filename="1.json' instead of 'file'.
Here is a fix for this.

P.S.
Chunks with Content-Type require better support (field contents will be something like this: 'Content-Type: application/octet-stream{ "something": 1 }' instead of '{"something": 1 }'.
Also the octet-stream fields should be treated differently, I'm not sure how exactly (maybe they should go to special "files" group or something else).